### PR TITLE
space-before-function-paren test updates for prettier-miscellaneous

### DIFF
--- a/tests/space-before-function-paren/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/space-before-function-paren/__snapshots__/jsfmt.spec.js.snap
@@ -133,3 +133,225 @@ var foo = {
 var foo = async () => 1;
 
 `;
+
+exports[`tsbaz.ts 1`] = `
+// Results of using spaceBeforeFunctionParen: true setting
+// should match results of using the following
+// tslint rule (with one exception marked):
+// "space-before-function-paren": [true, "always"]
+// (with no rules from "tslint:recommended")
+
+function foo() {
+  // ...
+}
+
+var bar = function() {
+  // ...
+};
+
+var bar = function foo() {
+  // ...
+};
+
+function baz<T>(a: T) {
+  // ...
+}
+
+// tslint seems to miss this one:
+var baz = function<T>(a: T) {
+  // ...
+};
+
+var baz = function foo<T>(a: T) {
+  // ...
+};
+
+class Foo {
+  constructor() {
+    // ...
+  }
+  public bar() {
+    // ...
+  }
+  public baz<T>(a: T) {
+    // ...
+  }
+}
+
+var foo = {
+  bar() {
+    // ...
+  },
+  baz<T>(a: T) {
+    // ...
+  }
+};
+
+var foo = async() => 1;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Results of using spaceBeforeFunctionParen: true setting
+// should match results of using the following
+// tslint rule (with one exception marked):
+// "space-before-function-paren": [true, "always"]
+// (with no rules from "tslint:recommended")
+
+function foo () {
+  // ...
+}
+
+var bar = function () {
+  // ...
+};
+
+var bar = function foo () {
+  // ...
+};
+
+function baz<T> (a: T) {
+  // ...
+}
+
+// tslint seems to miss this one:
+var baz = function<T> (a: T) {
+  // ...
+};
+
+var baz = function foo<T> (a: T) {
+  // ...
+};
+
+class Foo {
+  constructor () {
+    // ...
+  }
+  public bar () {
+    // ...
+  }
+  public baz<T> (a: T) {
+    // ...
+  }
+}
+
+var foo = {
+  bar () {
+    // ...
+  },
+  baz<T> (a: T) {
+    // ...
+  }
+};
+
+var foo = async () => 1;
+
+`;
+
+exports[`tsbaz.ts 2`] = `
+// Results of using spaceBeforeFunctionParen: true setting
+// should match results of using the following
+// tslint rule (with one exception marked):
+// "space-before-function-paren": [true, "always"]
+// (with no rules from "tslint:recommended")
+
+function foo() {
+  // ...
+}
+
+var bar = function() {
+  // ...
+};
+
+var bar = function foo() {
+  // ...
+};
+
+function baz<T>(a: T) {
+  // ...
+}
+
+// tslint seems to miss this one:
+var baz = function<T>(a: T) {
+  // ...
+};
+
+var baz = function foo<T>(a: T) {
+  // ...
+};
+
+class Foo {
+  constructor() {
+    // ...
+  }
+  public bar() {
+    // ...
+  }
+  public baz<T>(a: T) {
+    // ...
+  }
+}
+
+var foo = {
+  bar() {
+    // ...
+  },
+  baz<T>(a: T) {
+    // ...
+  }
+};
+
+var foo = async() => 1;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Results of using spaceBeforeFunctionParen: true setting
+// should match results of using the following
+// tslint rule (with one exception marked):
+// "space-before-function-paren": [true, "always"]
+// (with no rules from "tslint:recommended")
+
+function foo() {
+  // ...
+}
+
+var bar = function() {
+  // ...
+};
+
+var bar = function foo() {
+  // ...
+};
+
+function baz<T>(a: T) {
+  // ...
+}
+
+// tslint seems to miss this one:
+var baz = function<T>(a: T) {
+  // ...
+};
+
+var baz = function foo<T>(a: T) {
+  // ...
+};
+
+class Foo {
+  constructor() {
+    // ...
+  }
+  public bar() {
+    // ...
+  }
+  public baz<T>(a: T) {
+    // ...
+  }
+}
+
+var foo = {
+  bar() {
+    // ...
+  },
+  baz<T>(a: T) {
+    // ...
+  }
+};
+
+var foo = async () => 1;
+
+`;

--- a/tests/space-before-function-paren/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/space-before-function-paren/__snapshots__/jsfmt.spec.js.snap
@@ -60,3 +60,64 @@ var foo = {
 var foo = async () => 1;
 
 `;
+
+exports[`eslint.js 2`] = `
+/*eslint space-before-function-paren: "error"*/
+/*eslint-env es6*/
+
+function foo() {
+    // ...
+}
+
+var bar = function() {
+    // ...
+};
+
+var bar = function foo() {
+    // ...
+};
+
+class Foo {
+    constructor() {
+        // ...
+    }
+}
+
+var foo = {
+    bar() {
+        // ...
+    }
+};
+
+var foo = async() => 1
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/*eslint space-before-function-paren: "error"*/
+/*eslint-env es6*/
+
+function foo() {
+  // ...
+}
+
+var bar = function() {
+  // ...
+};
+
+var bar = function foo() {
+  // ...
+};
+
+class Foo {
+  constructor() {
+    // ...
+  }
+}
+
+var foo = {
+  bar() {
+    // ...
+  }
+};
+
+var foo = async () => 1;
+
+`;

--- a/tests/space-before-function-paren/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/space-before-function-paren/__snapshots__/jsfmt.spec.js.snap
@@ -20,6 +20,9 @@ class Foo {
     constructor() {
         // ...
     }
+    bar() {
+        // ...
+    }
 }
 
 var foo = {
@@ -47,6 +50,9 @@ var bar = function foo () {
 
 class Foo {
   constructor () {
+    // ...
+  }
+  bar () {
     // ...
   }
 }
@@ -81,6 +87,9 @@ class Foo {
     constructor() {
         // ...
     }
+    bar() {
+        // ...
+    }
 }
 
 var foo = {
@@ -108,6 +117,9 @@ var bar = function foo() {
 
 class Foo {
   constructor() {
+    // ...
+  }
+  bar() {
     // ...
   }
 }

--- a/tests/space-before-function-paren/eslint.js
+++ b/tests/space-before-function-paren/eslint.js
@@ -17,6 +17,9 @@ class Foo {
     constructor() {
         // ...
     }
+    bar() {
+        // ...
+    }
 }
 
 var foo = {

--- a/tests/space-before-function-paren/jsfmt.spec.js
+++ b/tests/space-before-function-paren/jsfmt.spec.js
@@ -2,3 +2,8 @@ run_spec(__dirname, { spaceBeforeFunctionParen: true }, [
   "babylon",
   "typescript"
 ]);
+
+run_spec(__dirname,  {}, [
+  "babylon",
+  "typescript"
+]);

--- a/tests/space-before-function-paren/tsbaz.ts
+++ b/tests/space-before-function-paren/tsbaz.ts
@@ -1,0 +1,53 @@
+// Results of using spaceBeforeFunctionParen: true setting
+// should match results of using the following
+// tslint rule (with one exception marked):
+// "space-before-function-paren": [true, "always"]
+// (with no rules from "tslint:recommended")
+
+function foo() {
+  // ...
+}
+
+var bar = function() {
+  // ...
+};
+
+var bar = function foo() {
+  // ...
+};
+
+function baz<T>(a: T) {
+  // ...
+}
+
+// tslint seems to miss this one:
+var baz = function<T>(a: T) {
+  // ...
+};
+
+var baz = function foo<T>(a: T) {
+  // ...
+};
+
+class Foo {
+  constructor() {
+    // ...
+  }
+  public bar() {
+    // ...
+  }
+  public baz<T>(a: T) {
+    // ...
+  }
+}
+
+var foo = {
+  bar() {
+    // ...
+  },
+  baz<T>(a: T) {
+    // ...
+  }
+};
+
+var foo = async() => 1;


### PR DESCRIPTION
* test with no `spaceBeforeFunctionParen` setting
* test with real member function
* add `space-before-function-paren` tslint test for additional TypeScript functionality, including generics (<https://www.typescriptlang.org/docs/handbook/generics.html>)

These added tests show the `space-before-function-paren` functionality working correctly in `prettier-miscellaneous`, as contributed in <https://github.com/arijs/prettier-miscellaneous/pull/22>.

(based on `prettier-miscellaneous-master` branch)