### PR TITLE
prettierx space-before-function-paren option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ prettierx <options> <file(s)>
 
 | Option | Default value | CLI Override | API Override | Description                    |
 | ------ | ------------- | ------------ | ------------ | ------------------------------ |
-| TBD    | TBD           | TBD          | TBD          | TBD                            |
+| Space before function parentheses | `false` | `--space-before-function-paren` | `spaceBeforeFunctionParen: <bool>` | Put a space before function parenthesis. |
 
 <!-- - FUTURE TBD prettierx vs prettier (???):
 ![Prettier Banner](https://raw.githubusercontent.com/prettier/prettier-logo/master/images/prettier-banner-light.png)

--- a/docs/options.md
+++ b/docs/options.md
@@ -170,6 +170,14 @@ These options cannot be used with `cursorOffset`.
 | `0`        | `--range-start <int>` | `rangeStart: <int>` |
 | `Infinity` | `--range-end <int>`   | `rangeEnd: <int>`   |
 
+## Space before function parentheses
+
+Put a space before function parenthesis.
+
+| Default | CLI Override                    | API Override                       |
+| ------- | ------------------------------- | ---------------------------------- |
+| `false` | `--space-before-function-paren` | `spaceBeforeFunctionParen: <bool>` |
+
 ## Parser
 
 Specify which parser to use.

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -40,6 +40,12 @@ module.exports = {
     oppositeDescription:
       "Do not print semicolons, except at the beginning of lines which may need them."
   },
+  spaceBeforeFunctionParen: {
+    category: CATEGORY_JAVASCRIPT,
+    type: "boolean",
+    default: false,
+    description: "Put a space before function parenthesis."
+  },
   singleQuote: commonOptions.singleQuote,
   jsxSingleQuote: {
     since: "1.15.0",

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3736,14 +3736,16 @@ function printMethod(path, options, print) {
     key = concat(["[", key, "]"]);
   }
 
+  parts.push(key);
+
   parts.push(
-    key,
     concat(
       path.call(
         valuePath => [
           printFunctionTypeParameters(valuePath, options, print),
           group(
             concat([
+              options.spaceBeforeFunctionParen ? " " : "",
               printFunctionParams(valuePath, print, options),
               printReturnType(valuePath, print, options)
             ])
@@ -4234,6 +4236,7 @@ function printFunctionDeclaration(path, print, options) {
     printFunctionTypeParameters(path, options, print),
     group(
       concat([
+              options.spaceBeforeFunctionParen ? " " : "",
         printFunctionParams(path, print, options),
         printReturnType(path, print, options)
       ])

--- a/tests/space-before-function-paren/eslint-compat/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/space-before-function-paren/eslint-compat/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,150 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`eslint.js 1`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+spaceBeforeFunctionParen: true
+                                                                                | printWidth
+=====================================input======================================
+/*eslint space-before-function-paren: "error"*/
+/*eslint-env es6*/
+
+function foo() {
+    // ...
+}
+
+var bar = function() {
+    // ...
+};
+
+var bar = function foo() {
+    // ...
+};
+
+class Foo {
+    constructor() {
+        // ...
+    }
+    bar() {
+        // ...
+    }
+}
+
+var foo = {
+    bar() {
+        // ...
+    }
+};
+
+var foo = async() => 1
+
+=====================================output=====================================
+/*eslint space-before-function-paren: "error"*/
+/*eslint-env es6*/
+
+function foo () {
+  // ...
+}
+
+var bar = function () {
+  // ...
+};
+
+var bar = function foo () {
+  // ...
+};
+
+class Foo {
+  constructor () {
+    // ...
+  }
+  bar () {
+    // ...
+  }
+}
+
+var foo = {
+  bar () {
+    // ...
+  }
+};
+
+var foo = async () => 1;
+
+================================================================================
+`;
+
+exports[`eslint.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/*eslint space-before-function-paren: "error"*/
+/*eslint-env es6*/
+
+function foo() {
+    // ...
+}
+
+var bar = function() {
+    // ...
+};
+
+var bar = function foo() {
+    // ...
+};
+
+class Foo {
+    constructor() {
+        // ...
+    }
+    bar() {
+        // ...
+    }
+}
+
+var foo = {
+    bar() {
+        // ...
+    }
+};
+
+var foo = async() => 1
+
+=====================================output=====================================
+/*eslint space-before-function-paren: "error"*/
+/*eslint-env es6*/
+
+function foo() {
+  // ...
+}
+
+var bar = function() {
+  // ...
+};
+
+var bar = function foo() {
+  // ...
+};
+
+class Foo {
+  constructor() {
+    // ...
+  }
+  bar() {
+    // ...
+  }
+}
+
+var foo = {
+  bar() {
+    // ...
+  }
+};
+
+var foo = async () => 1;
+
+================================================================================
+`;

--- a/tests/space-before-function-paren/eslint-compat/eslint.js
+++ b/tests/space-before-function-paren/eslint-compat/eslint.js
@@ -1,0 +1,31 @@
+/*eslint space-before-function-paren: "error"*/
+/*eslint-env es6*/
+
+function foo() {
+    // ...
+}
+
+var bar = function() {
+    // ...
+};
+
+var bar = function foo() {
+    // ...
+};
+
+class Foo {
+    constructor() {
+        // ...
+    }
+    bar() {
+        // ...
+    }
+}
+
+var foo = {
+    bar() {
+        // ...
+    }
+};
+
+var foo = async() => 1

--- a/tests/space-before-function-paren/eslint-compat/jsfmt.spec.js
+++ b/tests/space-before-function-paren/eslint-compat/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["flow", "typescript"], { spaceBeforeFunctionParen: true });
+run_spec(__dirname, ["flow", "typescript"]);

--- a/tests/space-before-function-paren/tslint-compat/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/space-before-function-paren/tslint-compat/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,238 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tsbaz.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+spaceBeforeFunctionParen: true
+                                                                                | printWidth
+=====================================input======================================
+// Results of using spaceBeforeFunctionParen: true setting
+// should match results of using the following
+// tslint rule (with one exception marked):
+// "space-before-function-paren": [true, "always"]
+// (with no rules from "tslint:recommended")
+
+function foo() {
+  // ...
+}
+
+var bar = function() {
+  // ...
+};
+
+var bar = function foo() {
+  // ...
+};
+
+function baz<T>(a: T) {
+  // ...
+}
+
+// tslint seems to miss this one:
+var baz = function<T>(a: T) {
+  // ...
+};
+
+var baz = function foo<T>(a: T) {
+  // ...
+};
+
+class Foo {
+  constructor() {
+    // ...
+  }
+  public bar() {
+    // ...
+  }
+  public baz<T>(a: T) {
+    // ...
+  }
+}
+
+var foo = {
+  bar() {
+    // ...
+  },
+  baz<T>(a: T) {
+    // ...
+  }
+};
+
+var foo = async() => 1;
+
+=====================================output=====================================
+// Results of using spaceBeforeFunctionParen: true setting
+// should match results of using the following
+// tslint rule (with one exception marked):
+// "space-before-function-paren": [true, "always"]
+// (with no rules from "tslint:recommended")
+
+function foo () {
+  // ...
+}
+
+var bar = function () {
+  // ...
+};
+
+var bar = function foo () {
+  // ...
+};
+
+function baz<T> (a: T) {
+  // ...
+}
+
+// tslint seems to miss this one:
+var baz = function<T> (a: T) {
+  // ...
+};
+
+var baz = function foo<T> (a: T) {
+  // ...
+};
+
+class Foo {
+  constructor () {
+    // ...
+  }
+  public bar () {
+    // ...
+  }
+  public baz<T> (a: T) {
+    // ...
+  }
+}
+
+var foo = {
+  bar () {
+    // ...
+  },
+  baz<T> (a: T) {
+    // ...
+  }
+};
+
+var foo = async () => 1;
+
+================================================================================
+`;
+
+exports[`tsbaz.ts 2`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// Results of using spaceBeforeFunctionParen: true setting
+// should match results of using the following
+// tslint rule (with one exception marked):
+// "space-before-function-paren": [true, "always"]
+// (with no rules from "tslint:recommended")
+
+function foo() {
+  // ...
+}
+
+var bar = function() {
+  // ...
+};
+
+var bar = function foo() {
+  // ...
+};
+
+function baz<T>(a: T) {
+  // ...
+}
+
+// tslint seems to miss this one:
+var baz = function<T>(a: T) {
+  // ...
+};
+
+var baz = function foo<T>(a: T) {
+  // ...
+};
+
+class Foo {
+  constructor() {
+    // ...
+  }
+  public bar() {
+    // ...
+  }
+  public baz<T>(a: T) {
+    // ...
+  }
+}
+
+var foo = {
+  bar() {
+    // ...
+  },
+  baz<T>(a: T) {
+    // ...
+  }
+};
+
+var foo = async() => 1;
+
+=====================================output=====================================
+// Results of using spaceBeforeFunctionParen: true setting
+// should match results of using the following
+// tslint rule (with one exception marked):
+// "space-before-function-paren": [true, "always"]
+// (with no rules from "tslint:recommended")
+
+function foo() {
+  // ...
+}
+
+var bar = function() {
+  // ...
+};
+
+var bar = function foo() {
+  // ...
+};
+
+function baz<T>(a: T) {
+  // ...
+}
+
+// tslint seems to miss this one:
+var baz = function<T>(a: T) {
+  // ...
+};
+
+var baz = function foo<T>(a: T) {
+  // ...
+};
+
+class Foo {
+  constructor() {
+    // ...
+  }
+  public bar() {
+    // ...
+  }
+  public baz<T>(a: T) {
+    // ...
+  }
+}
+
+var foo = {
+  bar() {
+    // ...
+  },
+  baz<T>(a: T) {
+    // ...
+  }
+};
+
+var foo = async () => 1;
+
+================================================================================
+`;

--- a/tests/space-before-function-paren/tslint-compat/jsfmt.spec.js
+++ b/tests/space-before-function-paren/tslint-compat/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["typescript"], { spaceBeforeFunctionParen: true });
+run_spec(__dirname, ["typescript"]);

--- a/tests/space-before-function-paren/tslint-compat/tsbaz.ts
+++ b/tests/space-before-function-paren/tslint-compat/tsbaz.ts
@@ -1,0 +1,53 @@
+// Results of using spaceBeforeFunctionParen: true setting
+// should match results of using the following
+// tslint rule (with one exception marked):
+// "space-before-function-paren": [true, "always"]
+// (with no rules from "tslint:recommended")
+
+function foo() {
+  // ...
+}
+
+var bar = function() {
+  // ...
+};
+
+var bar = function foo() {
+  // ...
+};
+
+function baz<T>(a: T) {
+  // ...
+}
+
+// tslint seems to miss this one:
+var baz = function<T>(a: T) {
+  // ...
+};
+
+var baz = function foo<T>(a: T) {
+  // ...
+};
+
+class Foo {
+  constructor() {
+    // ...
+  }
+  public bar() {
+    // ...
+  }
+  public baz<T>(a: T) {
+    // ...
+  }
+}
+
+var foo = {
+  bar() {
+    // ...
+  },
+  baz<T>(a: T) {
+    // ...
+  }
+};
+
+var foo = async() => 1;

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -82,6 +82,9 @@ Format options:
   --no-semi                Do not print semicolons, except at the beginning of lines which may need them.
   --single-quote           Use single quotes instead of double quotes.
                            Defaults to false.
+  --space-before-function-paren
+                           Put a space before function parenthesis.
+                           Defaults to false.
   --tab-width <int>        Number of spaces per indentation level.
                            Defaults to 2.
   --trailing-comma <none|es5|all>
@@ -230,6 +233,9 @@ Format options:
                            Defaults to preserve.
   --no-semi                Do not print semicolons, except at the beginning of lines which may need them.
   --single-quote           Use single quotes instead of double quotes.
+                           Defaults to false.
+  --space-before-function-paren
+                           Put a space before function parenthesis.
                            Defaults to false.
   --tab-width <int>        Number of spaces per indentation level.
                            Defaults to 2.

--- a/tests_integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/help-options.js.snap
@@ -490,6 +490,19 @@ Default: false
 
 exports[`show detailed usage with --help single-quote (write) 1`] = `Array []`;
 
+exports[`show detailed usage with --help space-before-function-paren (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help space-before-function-paren (stdout) 1`] = `
+"--space-before-function-paren
+
+  Put a space before function parenthesis.
+
+Default: false
+"
+`;
+
+exports[`show detailed usage with --help space-before-function-paren (write) 1`] = `Array []`;
+
 exports[`show detailed usage with --help stdin (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help stdin (stdout) 1`] = `

--- a/tests_integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests_integration/__tests__/__snapshots__/schema.js.snap
@@ -303,6 +303,11 @@ in order for it to be formatted.",
           "description": "Use single quotes instead of double quotes.",
           "type": "boolean",
         },
+        "spaceBeforeFunctionParen": Object {
+          "default": false,
+          "description": "Put a space before function parenthesis.",
+          "type": "boolean",
+        },
         "tabWidth": Object {
           "default": 2,
           "description": "Number of spaces per indentation level.",

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -40,8 +40,8 @@ exports[`API getSupportInfo() with version 0.0.0 -> 1.0.0 1`] = `
         \\"default\\": false,
         \\"type\\": \\"boolean\\",
       },
-      \\"tabWidth\\": Object {
-@@ -43,17 +59,15 @@
+      \\"spaceBeforeFunctionParen\\": Object {
+@@ -47,17 +63,15 @@
       \\"trailingComma\\": Object {
         \\"choices\\": Array [
           \\"none\\",
@@ -94,6 +94,10 @@ Object {
       "type": "int",
     },
     "singleQuote": Object {
+      "default": false,
+      "type": "boolean",
+    },
+    "spaceBeforeFunctionParen": Object {
       "default": false,
       "type": "boolean",
     },
@@ -1219,6 +1223,14 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"name\\": \\"singleQuote\\",
       \\"pluginDefaults\\": {},
       \\"since\\": \\"0.0.0\\",
+      \\"type\\": \\"boolean\\"
+    },
+    {
+      \\"category\\": \\"JavaScript\\",
+      \\"default\\": false,
+      \\"description\\": \\"Put a space before function parenthesis.\\",
+      \\"name\\": \\"spaceBeforeFunctionParen\\",
+      \\"pluginDefaults\\": {},
       \\"type\\": \\"boolean\\"
     },
     {


### PR DESCRIPTION
based on `prettier-miscellaneous` change from arijs/prettier-miscellaneous#22, largely reimplemented, with more updates as described in the commit message

Resolves #3 (supersedes PR #3).