### PR TITLE
[prettierx] drop Node.js 4 support

### DIFF
--- a/.azure-pipelines/jobs/prod-test-integration.yml
+++ b/.azure-pipelines/jobs/prod-test-integration.yml
@@ -1,0 +1,14 @@
+# TBD TEMPORARY WORKAROUND to test on Node.js 6
+# before dropping Node.js 4 support
+# Based on: .azure-pipelines/jobs/prod-test-integration.yml
+
+steps:
+  - template: ../steps/download-dist.yml
+  - template: ../steps/install-nodejs.yml
+  - template: ../steps/install-dependencies.yml
+    parameters:
+      flags: --ignore-engines # prettier@dev requires node v6+
+  - script: yarn test-integration
+    displayName: "Run tests on dist"
+  - template: ../steps/publish-test-results.yml
+  - template: ../steps/publish-code-coverage.yml

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Unofficial fork, intended to provide some additional options to help improve con
 
 Language parsers are supported as if this were `prettier` version `1.15.3` / `1.16.0`; old language parsers are deprecated as if this were `prettier` version `1.15.3` / `1.16.0`.
 
+Minimum Node.js version: 6
+
 ## CLI Usage
 
 **Quick CLI usage:**

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,6 +77,23 @@ jobs:
     steps:
       - template: .azure-pipelines/jobs/prod-lint.yml
 
+  # TBD TEMPORARY WORKAROUND here and in
+  # .azure-pipelines/jobs/prod-test-integration.yml
+  # to test on Node.js 6 before dropping Node.js 4 support
+  # FUTURE TODO: remove above workaround job file
+  # when this job can be removed.
+  - job: Prod_test_integration
+    dependsOn: Prod_Build
+    displayName: Prod test-integration on macOS
+    pool:
+      vmImage: macos-10.13
+    strategy:
+      matrix:
+        Node_v6:
+          node_version: 6
+    steps:
+      - template: .azure-pipelines/jobs/prod-test-integration.yml
+
   - job: Prod_Test
     dependsOn: Prod_Build
     displayName: Prod Test on macOS

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,6 +87,13 @@ jobs:
         Node_v4:
           node_version: 4
           ENABLE_TEST_RESULTS: "" # jest-junit requires node v6+
+        # TBD NOT WORKING on Node.js 6 for some reason
+        # (ALSO NOT WORKING on Linux or Windows):
+        # Node_v6:
+        #   node_version: 6
+        #   ...
+        Node_v8:
+          node_version: 8
         Node_v10:
           node_version: 10
         Node_v10_standalone:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,9 +101,6 @@ jobs:
       vmImage: macos-10.13
     strategy:
       matrix:
-        Node_v4:
-          node_version: 4
-          ENABLE_TEST_RESULTS: "" # jest-junit requires node v6+
         # TBD NOT WORKING on Node.js 6 for some reason
         # (ALSO NOT WORKING on Linux or Windows):
         # Node_v6:

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -77,7 +77,9 @@ async function cacheFiles() {
 async function preparePackage() {
   const pkg = await util.readJson("package.json");
   pkg.bin = "./bin-prettierx.js";
-  pkg.engines.node = ">=4";
+  // FUTURE TBD use this line to specify a different minimum
+  // Node.js version, if needed in the future:
+  // pkg.engines.node = ">=6";
   delete pkg.dependencies;
   delete pkg.devDependencies;
   pkg.scripts = {


### PR DESCRIPTION
and update Azure Pipelines to test on Node.js versions 6 & 8

(WORKAROUND SOLUTION was needed for Node.js version 6)

Resolves #25

ref: #26