### PR TITLE
[prettierx] cover standard ternary inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The following options should be used to _format_ the code according to [standard
 - `--no-semi` (`semi: false`)
 - `--yield-star-spacing` (`yieldStarSpacing: true`)
 
+Known conflict with `standard` in ternary returning objects ([brodybits/prettierx#40](https://github.com/brodybits/prettierx/issues/40))
+
 Note that this tool does _not_ follow any of the other [standard js](https://standardjs.com/) rules. It is recommended to use this tool together with eslint, in some form, to achive correct formatting according to [standard js](https://standardjs.com/).
 
 <!-- - FUTURE TBD prettierx vs prettier (???):

--- a/tests/standard/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/standard/__snapshots__/jsfmt.spec.js.snap
@@ -1069,6 +1069,33 @@ function*generator() {
 // "jsx-quotes": ["error", "prefer-single"],
 ;() => <div foo="bar" />
 
+// "indent": [
+//   "error",
+//   2,
+//   {
+//     "SwitchCase": 1,
+//     "VariableDeclarator": 1,
+//     "outerIIFEBody": 1,
+//     "MemberExpression": 1,
+//     "FunctionDeclaration": { "parameters": 1, "body": 1 },
+//     "FunctionExpression": { "parameters": 1, "body": 1 },
+//     "CallExpression": { "arguments": 1 },
+//     "ArrayExpression": 1,
+//     "ObjectExpression": 1,
+//     "ImportDeclaration": 1,
+//     "flatTernaryExpressions": false,
+//     "ignoreComments": false
+//   }
+// ],
+let isSpace = false
+const dress = isSpace ? {
+      spaceSuit: 3,
+      oxygenCylinders: 6
+    } : {
+      shirts: 3,
+      paints: 3
+    }
+
 =====================================output=====================================
 // "arrow-spacing": ["error", { "before": true, "after": true }]
 
@@ -1420,6 +1447,35 @@ function * generator () {
 
 // "jsx-quotes": ["error", "prefer-single"],
 ;() => <div foo='bar' />
+
+// "indent": [
+//   "error",
+//   2,
+//   {
+//     "SwitchCase": 1,
+//     "VariableDeclarator": 1,
+//     "outerIIFEBody": 1,
+//     "MemberExpression": 1,
+//     "FunctionDeclaration": { "parameters": 1, "body": 1 },
+//     "FunctionExpression": { "parameters": 1, "body": 1 },
+//     "CallExpression": { "arguments": 1 },
+//     "ArrayExpression": 1,
+//     "ObjectExpression": 1,
+//     "ImportDeclaration": 1,
+//     "flatTernaryExpressions": false,
+//     "ignoreComments": false
+//   }
+// ],
+let isSpace = false
+const dress = isSpace
+  ? {
+      spaceSuit: 3,
+      oxygenCylinders: 6
+    }
+  : {
+      shirts: 3,
+      paints: 3
+    }
 
 ================================================================================
 `;

--- a/tests/standard/incorrect.js
+++ b/tests/standard/incorrect.js
@@ -352,3 +352,30 @@ function*generator() {
 
 // "jsx-quotes": ["error", "prefer-single"],
 ;() => <div foo="bar" />
+
+// "indent": [
+//   "error",
+//   2,
+//   {
+//     "SwitchCase": 1,
+//     "VariableDeclarator": 1,
+//     "outerIIFEBody": 1,
+//     "MemberExpression": 1,
+//     "FunctionDeclaration": { "parameters": 1, "body": 1 },
+//     "FunctionExpression": { "parameters": 1, "body": 1 },
+//     "CallExpression": { "arguments": 1 },
+//     "ArrayExpression": 1,
+//     "ObjectExpression": 1,
+//     "ImportDeclaration": 1,
+//     "flatTernaryExpressions": false,
+//     "ignoreComments": false
+//   }
+// ],
+let isSpace = false
+const dress = isSpace ? {
+      spaceSuit: 3,
+      oxygenCylinders: 6
+    } : {
+      shirts: 3,
+      paints: 3
+    }


### PR DESCRIPTION
in tests/standard & docs

as reported in brodybits/prettierx#40

(this should have been part of the proposal in prettier/prettier#5723)

Note that this inconsistency is resolved by brodybits/prettierx#41
which is to be included in an upcoming merge.